### PR TITLE
Fix priority order of platform specific extensions

### DIFF
--- a/src/esbuild-config.js
+++ b/src/esbuild-config.js
@@ -10,6 +10,7 @@ const IMAGE_EXTENSIONS = BITMAP_IMAGE_EXTENSIONS.concat(
 );
 const VIDEO_EXTENSIONS = ['.mp4'];
 const ASSET_EXTENSIONS = IMAGE_EXTENSIONS.concat(VIDEO_EXTENSIONS);
+const SOURCE_EXTENSIONS = ['.tsx', '.ts', '.jsx', '.js', '.json'];
 
 function getEsbuildConfig(config, args) {
   const {
@@ -22,14 +23,12 @@ function getEsbuildConfig(config, args) {
     assetsPublicPath,
     sourcemapOutput,
   } = args;
-  const resolveExtensions = ['.tsx', '.ts', '.jsx', '.js', '.json']
-    .concat(ASSET_EXTENSIONS)
-    .map((extension) => [
-      `.${platform}${extension}`,
-      `.native${extension}`,
-      `.react-native${extension}`,
-      extension,
-    ])
+
+  const platforms = [platform, 'native', 'react-native'];
+  const extensions = SOURCE_EXTENSIONS.concat(ASSET_EXTENSIONS);
+  const resolveExtensions = platforms
+    .map((p) => extensions.map((e) => `.${p}${e}`))
+    .concat(extensions)
     .flat();
 
   return {


### PR DESCRIPTION
In some rare edge cases when mixing extensions it could happen that this bundler would pick the wrong file. 

### Current order (wrong)
```
file.ios.ts
file.ts
file.ios.js
file.js
```

### Proposed order (this pr)
```
file.ios.ts
file.ios.js
file.ts
file.js
```