### PR TITLE
Set process.env.NODE_ENV explicitly

### DIFF
--- a/src/esbuild-config.js
+++ b/src/esbuild-config.js
@@ -42,6 +42,9 @@ function getEsbuildConfig(config, args) {
     define: {
       __DEV__: dev,
       global: 'window',
+      'process.env.NODE_ENV': JSON.stringify(
+        dev ? 'development' : 'production'
+      ),
     },
     loader: {
       '.js': 'jsx',


### PR DESCRIPTION
While `minify` and `dev` settings typically go hand in hand, they _can_ differ and therefore `process.env.NODE_ENV` should be set explicitly and not be inferred from `minify` by esbuild.