### PR TITLE
Add more logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Fast bundler and dev server for react-native using esbuild",
   "main": "src/index",
   "scripts": {
+    "format": "prettier src --write",
     "test": "uvu src .spec.js",
     "test-ios": "FORCE_BUNDLING=1 xcodebuild test -workspace Example/ios/Example.xcworkspace -scheme 'Example' -destination 'platform=iOS Simulator,name=iPhone 13'"
   },
@@ -38,6 +39,7 @@
     "@babel/plugin-transform-react-jsx": "^7.17.12",
     "@react-native-community/cli-server-api": "^8.0.0",
     "@react-native-community/cli-tools": "^8.0.0",
+    "chalk": "^4.1.2",
     "fs-extra": "^10.1.0",
     "image-size": "^1.0.1",
     "source-map": "^0.7.3"

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -71,7 +71,6 @@ function createEsbuildCommands(
         },
         {
           name: '--host <string>',
-          default: '',
         },
         {
           name: '--projectRoot <path>',

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -5,6 +5,7 @@ const {
   createDevServerMiddleware,
   indexPageMiddleware,
 } = require('@react-native-community/cli-server-api');
+const chalk = require('chalk');
 const {
   createBundler,
   serveAsset,
@@ -13,10 +14,15 @@ const {
   enableInteractiveMode,
 } = require('../server');
 const { emptyDefaultCacheDir } = require('../cache');
+const { defaultLogger } = require('../logger');
 
 const ASSETS_PUBLIC_PATH = '/assets/';
 
 module.exports = (getBundleConfig) => async (_, config, args) => {
+  // Hermes for some reason hijacks this upon import and messes with stack traces
+  process.removeAllListeners('uncaughtException');
+  process.removeAllListeners('unhandledRejection');
+
   const {
     host = '127.0.0.1',
     port = 8081,
@@ -48,7 +54,8 @@ module.exports = (getBundleConfig) => async (_, config, args) => {
         ...options,
         assetsPublicPath: ASSETS_PUBLIC_PATH,
       }),
-    reload
+    reload,
+    defaultLogger
   );
 
   middleware.use(async (req, res, next) => {
@@ -125,6 +132,9 @@ module.exports = (getBundleConfig) => async (_, config, args) => {
   });
 
   server.listen(port);
+
+  const LOGO = chalk.bgHex('#FFCF00').hex('#000000')('»');
+  console.log(`${LOGO} esbuild listening on http://${host}:${port}\n`);
 
   if (interactive) {
     enableInteractiveMode(messageSocketEndpoint);

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,21 @@
+const path = require('path');
+const chalk = require('chalk');
+
+const createLog =
+  (color, log = console.log) =>
+  (category, message) => {
+    log(`${color.inverse.bold(` ${category.toUpperCase()} `)} ${message}`);
+  };
+
+const defaultLogger = {
+  warn: createLog(chalk.yellow),
+  success: createLog(chalk.green),
+  error: createLog(chalk.red),
+};
+
+const formatFilePath = (filePath) =>
+  `${chalk.dim(`${path.dirname(filePath)}/`)}${chalk.bold(
+    path.basename(filePath)
+  )}`;
+
+module.exports = { defaultLogger, formatFilePath };

--- a/src/server/bundler.js
+++ b/src/server/bundler.js
@@ -25,11 +25,14 @@ function createBundler(getBundleConfig, onBuild, logger) {
     if (!promiseMap[bundleOutput]) {
       let buildResolver = null;
       let buildRejecter = null;
+      let buildStart = -1;
+
       const setupBuildPromise = () => {
         const promise = new Promise((resolve, reject) => {
           buildResolver = resolve;
           buildRejecter = reject;
         });
+        buildStart = Date.now();
         // Rejections are generally caught and forwarded to the app
         // but rebuilds aren't being awaited instantly and we don't
         // want to kill the process in those cases.
@@ -64,7 +67,9 @@ function createBundler(getBundleConfig, onBuild, logger) {
             }
             logger.warn(
               'BUNDLE',
-              `${formatFilePath(localPath)}: ${chalk.dim('Building...')}`
+              `${formatFilePath(localPath)}: ${chalk.dim(
+                `${platform} building...`
+              )}`
             );
           });
 
@@ -76,7 +81,7 @@ function createBundler(getBundleConfig, onBuild, logger) {
               logger.success(
                 'BUNDLE',
                 `${formatFilePath(localPath)}: ${chalk.dim(
-                  'Build successful.'
+                  `${platform} build completed in ${Date.now() - buildStart}ms`
                 )}`
               );
               const file = outputFiles.find((f) => f.path === bundleOutput);
@@ -88,7 +93,7 @@ function createBundler(getBundleConfig, onBuild, logger) {
               logger.error(
                 'BUNDLE',
                 `${formatFilePath(localPath)}: ${chalk.bold.red(
-                  'Build failed, see errors above.'
+                  `${platform} build failed, see errors above`
                 )}`
               );
               buildRejecter(

--- a/src/server/interactive-mode.js
+++ b/src/server/interactive-mode.js
@@ -2,7 +2,7 @@ const readline = require('readline');
 const { logger } = require('@react-native-community/cli-tools');
 
 function printInteractiveModeInstructions() {
-  logger.log('To reload the app press "r"\nTo open developer menu press "d"');
+  logger.log('To reload the app press "r"\nTo open developer menu press "d"\n');
 }
 
 function enableInteractiveMode(messageSocket) {


### PR DESCRIPTION
Users have complained about lack of console output, so this PR addresses that. Jest/metro behavior is to rewrite console output (Yellow -> Green background etc) but that is kinda messy to do, doesn't work in all terminals (esp non-interactive like CIs) and you have to worry about rogue output (aka probably monkey patch console.log). Since there is no progress output it's not a strict requirement, so leaving this for a potential future improvement. 

Example:
<img width="325" alt="Screenshot 2022-06-15 at 11 56 04" src="https://user-images.githubusercontent.com/378279/173800007-ee390e5b-595a-4f33-b324-55f5d9db7ef7.png">

Additionally it fixes a bug where a failed rebuild would make the dev server shut down which is not how metro works. 