### PR TITLE
Enable log forwarding and live reload over HMR socket

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -8,6 +8,7 @@ const createLog =
   };
 
 const defaultLogger = {
+  log: createLog(chalk.white),
   warn: createLog(chalk.yellow),
   success: createLog(chalk.green),
   error: createLog(chalk.red),

--- a/src/server/hmr-endpoint.js
+++ b/src/server/hmr-endpoint.js
@@ -1,0 +1,57 @@
+const { Server } = require('ws');
+
+function createHMREndpoint(logger) {
+  const server = new Server({ noServer: true });
+
+  let clientSocket;
+
+  function sendSafely(type, body) {
+    if (clientSocket) {
+      clientSocket.send(JSON.stringify({ type, body }));
+    }
+  }
+
+  function reload() {
+    // Esbuild doesn't support HMR, but we can hack the update API
+    // to implement an opt-in live reload functionality
+    sendSafely('update', {
+      added: [
+        {
+          module: [
+            'esbuild_reload_hack',
+            '(window.__turboModuleProxy ? window.__turboModuleProxy("DevSettings") : window.nativeModuleProxy["DevSettings"]).reload();',
+          ],
+          sourceURL: null,
+        },
+      ],
+      deleted: [],
+      modified: [],
+    });
+  }
+
+  const socketCloseHandler = () => {
+    clientSocket = null;
+  };
+
+  server.on('connection', (socket, request) => {
+    clientSocket = socket;
+    clientSocket.onerror = socketCloseHandler;
+    clientSocket.onclose = socketCloseHandler;
+    clientSocket.onmessage = ({ data }) => {
+      const event = JSON.parse(data);
+      switch (event.type) {
+        case 'log':
+          const log = logger[event.level] || logger.log;
+          log(event.level, event.data);
+          break;
+      }
+    };
+  });
+
+  return {
+    server,
+    reload,
+  };
+}
+
+module.exports = { createHMREndpoint };

--- a/src/server/index.js
+++ b/src/server/index.js
@@ -3,6 +3,7 @@ const { createBundler } = require('./bundler');
 const { extractBundleParams } = require('./extract-bundle-params');
 const { symbolicateStack } = require('./symbolicate');
 const { enableInteractiveMode } = require('./interactive-mode');
+const { createHMREndpoint } = require('./hmr-endpoint');
 
 module.exports = {
   serveAsset,
@@ -10,4 +11,5 @@ module.exports = {
   extractBundleParams,
   symbolicateStack,
   enableInteractiveMode,
+  createHMREndpoint,
 };


### PR DESCRIPTION
With metro, React Native will proxy console.logs to the HMR server that then gets logged to the terminal, a functionality currently lacking in this library. 

This PR implements a basic HMR endpoint simply for log forwarding purposes. When that is established we can also hack the HMR `update` API to inject arbitrary code to force a reload of the application. Currently that is done via the message socket that is primarily intended for user interaction with the terminal process and therefore would often throw warnings when no clients are connected (for example because they are loading the bundle). This approach also sucks because there is no way to opt out of it. With the HMR hack we get ability to opt out via the dev menu just like with metro. 