### PR TITLE
Don't transform JSX with babel

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "dependencies": {
     "@babel/code-frame": "^7.16.7",
     "@babel/plugin-syntax-flow": "^7.17.12",
+    "@babel/plugin-syntax-jsx": "^7.17.12",
     "@babel/plugin-transform-flow-strip-types": "^7.17.12",
-    "@babel/plugin-transform-react-jsx": "^7.17.12",
     "@react-native-community/cli-server-api": "^8.0.0",
     "@react-native-community/cli-tools": "^8.0.0",
     "chalk": "^4.1.2",

--- a/src/esbuild-config.js
+++ b/src/esbuild-config.js
@@ -95,14 +95,14 @@ function getEsbuildConfig(config, args) {
       babelPlugin({
         filter: new RegExp(`node_modules/([^/]*react-native[^/]*)/.+\\.jsx?$`),
         cache: dev,
+        loader: 'jsx',
         config: {
-          filename: bundleOutput,
           babelrc: false,
           configFile: false,
           plugins: [
             '@babel/plugin-syntax-flow',
             '@babel/plugin-transform-flow-strip-types',
-            '@babel/plugin-transform-react-jsx',
+            '@babel/plugin-syntax-jsx',
           ],
         },
       }),

--- a/src/plugins/babel.js
+++ b/src/plugins/babel.js
@@ -14,6 +14,7 @@ const babelPlugin = (options = {}) => ({
       filter = /.*/,
       namespace = '',
       cache = true,
+      loader = 'js',
       config = {},
     } = options;
     const transformCache = new Map();
@@ -82,7 +83,7 @@ const babelPlugin = (options = {}) => ({
           }
         }
 
-        return { contents: entry.transformed };
+        return { contents: entry.transformed, loader };
       } finally {
         if (handle) {
           handle.close();

--- a/yarn.lock
+++ b/yarn.lock
@@ -52,13 +52,6 @@
     "@jridgewell/gen-mapping" "^0.3.0"
     jsesc "^2.5.1"
 
-"@babel/helper-annotate-as-pure@^7.16.7":
-  version "7.16.7"
-  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz#bb2339a7534a9c128e3102024c60760a3a7f3862"
-  integrity sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==
-  dependencies:
-    "@babel/types" "^7.16.7"
-
 "@babel/helper-compilation-targets@^7.17.10":
   version "7.17.10"
   resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.17.10.tgz#09c63106d47af93cf31803db6bc49fef354e2ebe"
@@ -186,17 +179,6 @@
     "@babel/helper-plugin-utils" "^7.17.12"
     "@babel/plugin-syntax-flow" "^7.17.12"
 
-"@babel/plugin-transform-react-jsx@^7.17.12":
-  version "7.17.12"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.12.tgz#2aa20022709cd6a3f40b45d60603d5f269586dba"
-  integrity sha512-Lcaw8bxd1DKht3thfD4A12dqo1X16he1Lm8rIv8sTwjAYNInRS1qHa9aJoqvzpscItXvftKDCfaEQzwoVyXpEQ==
-  dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.7"
-    "@babel/helper-module-imports" "^7.16.7"
-    "@babel/helper-plugin-utils" "^7.17.12"
-    "@babel/plugin-syntax-jsx" "^7.17.12"
-    "@babel/types" "^7.17.12"
-
 "@babel/template@^7.16.7":
   version "7.16.7"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.16.7.tgz#8d126c8701fde4d66b264b3eba3d96f07666d155"
@@ -222,7 +204,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.16.7", "@babel/types@^7.17.0", "@babel/types@^7.17.12", "@babel/types@^7.18.0":
+"@babel/types@^7.16.7", "@babel/types@^7.17.0", "@babel/types@^7.18.0":
   version "7.18.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.18.0.tgz#ef523ea349722849cb4bf806e9342ede4d071553"
   integrity sha512-vhAmLPAiC8j9K2GnsnLPCIH5wCrPpYIVBCWRBFDCB7Y/BXLqi/O+1RSTTM2bsmg6U/551+FCf9PNPxjABmxHTw==


### PR DESCRIPTION
When stripping Flow syntax with babel, there is no point in also transforming JSX syntax. Moving this to esbuild itself makes a full `esbuild-bundle` ~6% faster on a vanilla project. 