### PR TITLE
Put all static assets in assets folder

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -6,7 +6,7 @@
     "android": "react-native run-android --no-packager",
     "ios": "react-native run-ios --no-packager",
     "start": "react-native esbuild-start",
-    "bundle": "rm -rf build && mkdir build && react-native esbuild-bundle --bundle-output ./build/index.bundle --assets-dest ./build/assets",
+    "bundle": "rm -rf build && mkdir build && react-native esbuild-bundle --bundle-output ./build/index.bundle --assets-dest ./build",
     "test": "jest",
     "lint": "eslint .",
     "postinstall": "DESTINATION='node_modules/react-native-esbuild' LIB_FILE=`cd .. && echo \\`pwd\\`/\\`npm pack\\`` && (rm -rf $DESTINATION || true) && mkdir $DESTINATION && tar -xvzf $LIB_FILE -C $DESTINATION --strip-components 1 && rm $LIB_FILE"

--- a/src/commands/start.js
+++ b/src/commands/start.js
@@ -16,8 +16,7 @@ const {
 } = require('../server');
 const { emptyDefaultCacheDir } = require('../cache');
 const { defaultLogger } = require('../logger');
-
-const ASSETS_PUBLIC_PATH = '/assets/';
+const { ASSETS_PUBLIC_PATH } = require('../config');
 
 module.exports = (getBundleConfig) => async (_, config, args) => {
   // Hermes for some reason hijacks this upon import and messes with stack traces
@@ -46,11 +45,7 @@ module.exports = (getBundleConfig) => async (_, config, args) => {
   const hmr = createHMREndpoint(defaultLogger);
 
   const bundler = createBundler(
-    (options) =>
-      getBundleConfig(config, {
-        ...options,
-        assetsPublicPath: ASSETS_PUBLIC_PATH,
-      }),
+    (options) => getBundleConfig(config, options),
     hmr.reload,
     defaultLogger
   );

--- a/src/config.js
+++ b/src/config.js
@@ -1,0 +1,3 @@
+const ASSETS_PUBLIC_PATH = '/assets/';
+
+module.exports = { ASSETS_PUBLIC_PATH };

--- a/src/esbuild-config.js
+++ b/src/esbuild-config.js
@@ -23,7 +23,6 @@ function getEsbuildConfig(config, args) {
     minify,
     bundleOutput,
     assetsDest,
-    assetsPublicPath,
     sourcemapOutput,
   } = args;
 
@@ -88,7 +87,6 @@ function getEsbuildConfig(config, args) {
         scalableExtensions: BITMAP_IMAGE_EXTENSIONS,
         platform,
         rootdir: config.root,
-        publicPath: assetsPublicPath,
         outdir: assetsDest,
         dev,
       }),

--- a/src/plugins/asset-loader.js
+++ b/src/plugins/asset-loader.js
@@ -5,6 +5,7 @@ const { promisify } = require('util');
 const imageSize = require('image-size');
 const sizeOf = promisify(imageSize);
 const { getAssetDestinationPath } = require('./asset-destination');
+const { ASSETS_PUBLIC_PATH } = require('../config');
 
 function escapeRegex(string) {
   return string.replace(/[-/\\^$*+?.()|[\]{}]/g, '\\$&');
@@ -36,7 +37,7 @@ const assetLoaderPlugin = ({
   rootdir,
   outdir,
   dev = false,
-  publicPath = '/',
+  publicPath = ASSETS_PUBLIC_PATH,
   assetRegistryPath = '@react-native/assets/registry.js',
 } = {}) => ({
   name: 'react-native-asset-loader',


### PR DESCRIPTION
Force start and bundle to use existing pattern of putting all non-bundle assets into an `assets` folder. 